### PR TITLE
Fix misalignment of title text

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -227,7 +227,10 @@ Item {
             PlasmaComponents.Label{
                 id: labelTxt
 
-                anchors.centerIn: parent
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                verticalAlignment: Text.AlignVCenter
+                anchors.horizontalCenter: parent.horizontalCenter
                 width: {
                     if (plasmoid.configuration.maximumLength <= 0) {
                         return implicitWidth;


### PR DESCRIPTION
Blatantly taken from https://phabricator.kde.org/R884:1119c47f1756be9d302327f51c31f25e0f4d4e56
Should fix #15.
Result of commit:
![image](https://user-images.githubusercontent.com/16624211/48651097-6274c000-ea4d-11e8-8d32-478a32de2772.png)
