### PR TITLE
Add Libreoffice to default substitutions

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -117,11 +117,11 @@
     <default>0</default>
   </entry>
   <entry name="subsMatch" type="StringList">
-    <default>"Telegram Desktop","Gimp-.*"</default>
+    <default>"Telegram Desktop","Gimp-.*","soffice.bin"</default>
     <label>substitutions criteria - match for application names</label>
   </entry>
   <entry name="subsReplace" type="StringList">
-    <default>"Telegram","Gimp"</default>
+    <default>"Telegram","Gimp","LibreOffice"</default>
     <label>substitutions replacements for application names</label>
   </entry>
   <entry name="actionScrollMinimize" type="Bool">


### PR DESCRIPTION
Window Title Applet displays LibreOffice's name as "soffice.bin", which is ugly. "LibreOffice" is much better. It is quite a common application (probably more so than Telegram Desktop:-)).

Actually, Plasma displays it correctly with the program, so it shows "LibreOffice - Writer", not just "LibreOffice". (well, there should be an emdash, but that is somebody else's bug)
![Screenshot_20220107_134640](https://user-images.githubusercontent.com/1218098/148546112-578998eb-da96-4e57-861a-692e2867ef83.png)
.