### PR TITLE
Change plasmapkg2 to kpackagetool5 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ This is a Plasma 5 applet that shows the current window title and icon in your p
 
 # Install
 
-This is a QML applet and as such it can be easily installed from Plasma 5 Widgets Explorer or alternative you can execute `plasmapkg2 -i .` in the root directory of the applet.
+This is a QML applet and as such it can be easily installed from Plasma 5 Widgets Explorer or alternative you can execute `kpackagetool5 -i .` in the root directory of the applet.
 
 


### PR DESCRIPTION
On some machines (e.g. my Manjaro KDE one), `plasmapkg2` is no longer available. On others, it's simply an alias for `kpackagetool5`. For example, on Fedora, `plasmapkg -v` outputs `kpackagetool5 2.0`.
Usage appears to be exactly the same, so there shouldn't be any harm in replacing it.
The same line in the README also mentions `Plasma 5`, which always comes with `kpackagetool5`, so compatibility shouldn't be an issue.

BTW, thanks for creating and maintaining the app, starred :)