### PR TITLE
Update main.qml (No "Default" fallback text and compatibility for apps with blank titles when using "Application" Text Style)

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -126,6 +126,7 @@ Item {
     readonly property Item activeTaskItem: windowInfoLoader.item.activeTaskItem
 
     property string fallBackText: {
+        if(fullActivityInfo.name === "Default") { return "    "; } // WHITESPACE SO USER CAN STILL ACCESS CONFIGURATION
         if (!plasmoid.configuration.filterActivityInfo) {
             return plasmoid.configuration.placeHolder;
         } else {
@@ -139,7 +140,11 @@ Item {
         }
 
         if (plasmoid.configuration.style === 0){ /*Application*/
-            return Tools.applySubstitutes(activeTaskItem.appName);
+            if(activeTaskItem.appName !== "") {
+                return Tools.applySubstitutes(activeTaskItem.appName);
+            } else { // USE TITLE INSTEAD IF BLANK (WINE, JAVA, ETC)
+                return Tools.applySubstitutes(activeTaskItem.title);
+            }
         } else if (plasmoid.configuration.style === 1){ /*Title*/
             return activeTaskItem.title;
         } else if (plasmoid.configuration.style === 2){ /*ApplicationTitle*/


### PR DESCRIPTION
Do not show "Default" text when at Desktop level (fallBackText)
When using "Application" Text Style, use App Title instead if the App Name is blank (Java, Wine, etc)